### PR TITLE
Updating CAOS addon to support new function names.

### DIFF
--- a/controller/addons/caos-host-analyticsjs-local/caos-host-analyticsjs-local.php
+++ b/controller/addons/caos-host-analyticsjs-local/caos-host-analyticsjs-local.php
@@ -9,35 +9,35 @@ use cookiebot_addons\lib\script_loader_tag\Script_Loader_Tag_Interface;
 use cookiebot_addons\lib\Settings_Service_Interface;
 
 class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
-	
+
 	/**
 	 * @var Settings_Service_Interface
 	 *
 	 * @since 1.3.0
 	 */
 	protected $settings;
-	
+
 	/**
 	 * @var Script_Loader_Tag_Interface
 	 *
 	 * @since 1.3.0
 	 */
 	protected $script_loader_tag;
-	
+
 	/**
 	 * @var Cookie_Consent_Interface
 	 *
 	 * @since 1.3.0
 	 */
 	protected $cookie_consent;
-	
+
 	/**
 	 * @var Buffer_Output_Interface
 	 *
 	 * @since 1.3.0
 	 */
 	protected $buffer_output;
-	
+
 	/**
 	 * Complete Analytics Optimization Suite (CAOS) (Host Analyticsjs Local) constructor.
 	 *
@@ -54,7 +54,7 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 		$this->cookie_consent    = $cookie_consent;
 		$this->buffer_output     = $buffer_output;
 	}
-	
+
 	/**
 	 * Loads addon configuration
 	 *
@@ -63,7 +63,7 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 	public function load_configuration() {
 		add_action( 'wp_loaded', array( $this, 'cookiebot_addon_host_analyticsjs_local' ), 5 );
 	}
-	
+
 	/**
 	 * Check for Host Analyticsjs Local action hooks
 	 *
@@ -74,12 +74,12 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 		if ( ! function_exists( 'cookiebot_active' ) || ! cookiebot_active() ) {
 			return;
 		}
-		
+
 		// consent is given
 		if ( $this->cookie_consent->are_cookie_states_accepted( $this->get_cookie_types() ) ) {
 			return;
 		}
-		
+
 		/* Priority need to be more than 0 so we are able to hook in before output begins */
 		$scriptPriority = $this->cookiebot_addon_host_analyticsjs_local_priority();
 		if ( $scriptPriority <= 0 ) {
@@ -87,11 +87,11 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 			$scriptPriority = 2;
 			update_option( 'sgal_enqueue_order', $scriptPriority );
 		}
-		
+
 		/**
 		 * ga scripts are loaded in wp_footer priority is defined in option variable
 		 */
-		if ( has_action( 'wp_footer', 'add_ga_header_script' ) ) {
+		if ( has_action( 'wp_footer', 'caos_analytics_render_tracking_code') || has_action( 'wp_footer', 'add_ga_header_script' ) ) {
 			/**
 			 * Consent not given - no cache
 			 */
@@ -99,11 +99,11 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 				'GoogleAnalyticsObject' => $this->get_cookie_types(),
 			), false );
 		}
-		
+
 		/**
 		 * ga scripts are loaded in wp_head priority is defined in option variable
 		 */
-		if ( has_action( 'wp_head', 'add_ga_header_script' ) ) {
+		if ( has_action( 'wp_head', 'caos_analytics_render_tracking_code' ) || has_action( 'wp_head', 'add_ga_header_script' ) ) {
 			/**
 			 * Consent not given - no cache
 			 */
@@ -111,9 +111,9 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 				'GoogleAnalyticsObject' => $this->get_cookie_types(),
 			), false );
 		}
-		
+
 	}
-	
+
 	/**
 	 * Get priority of script
 	 *
@@ -124,7 +124,7 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 	public function cookiebot_addon_host_analyticsjs_local_priority() {
 		return ( esc_attr( get_option( 'sgal_enqueue_order' ) ) ) ? esc_attr( get_option( 'sgal_enqueue_order' ) ) : 0;
 	}
-	
+
 	/**
 	 * Return addon/plugin name
 	 *
@@ -135,7 +135,7 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 	public function get_addon_name() {
 		return 'Complete Analytics Optimization Suite (CAOS)';
 	}
-	
+
 	/**
 	 * Option name in the database
 	 *
@@ -146,7 +146,7 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 	public function get_option_name() {
 		return 'caos_host_analyticsjs_local';
 	}
-	
+
 	/**
 	 * plugin file name
 	 *
@@ -157,7 +157,7 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 	public function get_plugin_file() {
 		return 'host-analyticsjs-local/save-ga-local.php';
 	}
-	
+
 	/**
 	 * Returns checked cookie types
 	 * @return array
@@ -167,7 +167,7 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 	public function get_cookie_types() {
 		return $this->settings->get_cookie_types( $this->get_option_name(), $this->get_default_cookie_types() );
 	}
-	
+
 	/**
 	 * Returns default cookie types
 	 * @return array
@@ -177,7 +177,7 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 	public function get_default_cookie_types() {
 		return array( 'statistics' );
 	}
-	
+
 	/**
 	 * Check if plugin is activated and checked in the backend
 	 *
@@ -186,7 +186,7 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 	public function is_addon_enabled() {
 		return $this->settings->is_addon_enabled( $this->get_option_name() );
 	}
-	
+
 	/**
 	 * Checks if addon is installed
 	 *
@@ -195,7 +195,7 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 	public function is_addon_installed() {
 		return $this->settings->is_addon_installed( $this->get_plugin_file() );
 	}
-	
+
 	/**
 	 * Checks if addon is activated
 	 *
@@ -204,7 +204,7 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 	public function is_addon_activated() {
 		return $this->settings->is_addon_activated( $this->get_plugin_file() );
 	}
-	
+
 	/**
 	 * Default placeholder content
 	 *
@@ -215,7 +215,7 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 	public function get_default_placeholder() {
 		return 'Please accept [renew_consent]%cookie_types[/renew_consent] cookies to enable tracking.';
 	}
-	
+
 	/**
 	 * Get placeholder content
 	 *
@@ -231,7 +231,7 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 	public function get_placeholder( $src = '' ) {
 		return $this->settings->get_placeholder( $this->get_option_name(), $this->get_default_placeholder(), cookiebot_addons_output_cookie_types( $this->get_cookie_types() ), $src );
 	}
-	
+
 	/**
 	 * Checks if it does have custom placeholder content
 	 *
@@ -242,7 +242,7 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 	public function has_placeholder() {
 		return $this->settings->has_placeholder( $this->get_option_name() );
 	}
-	
+
 	/**
 	 * returns all placeholder contents
 	 *
@@ -253,7 +253,7 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 	public function get_placeholders() {
 		return $this->settings->get_placeholders( $this->get_option_name() );
 	}
-	
+
 	/**
 	 * Return true if the placeholder is enabled
 	 *
@@ -264,7 +264,7 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 	public function is_placeholder_enabled() {
 		return $this->settings->is_placeholder_enabled( $this->get_option_name() );
 	}
-	
+
 	/**
 	 * Adds extra information under the label
 	 *
@@ -275,7 +275,7 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 	public function get_extra_information() {
 		return false;
 	}
-	
+
 	/**
 	 * Returns the url of WordPress SVN repository or another link where we can verify the plugin file.
 	 *
@@ -286,7 +286,7 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 	public function get_svn_url() {
 		return 'http://plugins.svn.wordpress.org/host-analyticsjs-local/trunk/save-ga-local.php';
 	}
-	
+
 	/**
 	 * Placeholder helper overlay in the settings page.
 	 *

--- a/controller/addons/embed-autocorrect/embed-autocorrect.php
+++ b/controller/addons/embed-autocorrect/embed-autocorrect.php
@@ -9,35 +9,35 @@ use cookiebot_addons\lib\Cookie_Consent_Interface;
 use cookiebot_addons\lib\Settings_Service_Interface;
 
 class Embed_Autocorrect implements Cookiebot_Addons_Interface {
-	
+
 	/**
 	 * @var Settings_Service_Interface
 	 *
 	 * @since 1.3.0
 	 */
 	protected $settings;
-	
+
 	/**
 	 * @var Script_Loader_Tag_Interface
 	 *
 	 * @since 1.3.0
 	 */
 	protected $script_loader_tag;
-	
+
 	/**
 	 * @var Cookie_Consent_Interface
 	 *
 	 * @since 1.3.0
 	 */
 	protected $cookie_consent;
-	
+
 	/**
 	 * @var Buffer_Output_Interface
 	 *
 	 * @since 1.3.0
 	 */
 	protected $buffer_output;
-	
+
 	/**
 	 * Jetpack constructor.
 	 *
@@ -54,7 +54,7 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 		$this->cookie_consent    = $cookie_consent;
 		$this->buffer_output     = $buffer_output;
 	}
-	
+
 	/**
 	 * Loads addon configuration
 	 *
@@ -67,7 +67,7 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 		 */
 		add_action( 'wp_loaded', array( $this, 'cookiebot_addon_embed_autocorrect' ) );
 	}
-	
+
 	/**
 	 * Check for embed autocorrect action hooks
 	 *
@@ -78,44 +78,44 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 		if ( ! function_exists( 'cookiebot_active' ) || ! cookiebot_active() ) {
 			return;
 		}
-		
+
 		// consent is given
 		if ( $this->cookie_consent->are_cookie_states_accepted( $this->get_cookie_types() ) ) {
 			return;
 		}
-		
+
 		//add filters to handle autocorrection in content
 		add_filter( 'the_content', array(
 			$this,
 			'cookiebot_addon_embed_autocorrect_content'
 		), 1000 ); //Ensure it is executed as the last filter
-		
+
 		//add filters to handle autocorrection in widget text
 		add_filter( 'widget_text', array(
 			$this,
 			'cookiebot_addon_embed_autocorrect_content'
 		), 1000 ); //Ensure it is executed as the last filter
-		
-		
+
+
 		//add fitler to handle video shortcodes
 		add_filter( 'wp_video_shortcode', array(
 			$this,
 			'cookiebot_addon_embed_autocorrect_handle_video'
-		), 1000 ); 
-		
+		), 1000 );
+
 		//add fitler to handle audio shortcodes
 		add_filter( 'wp_audio_shortcode', array(
 			$this,
 			'cookiebot_addon_embed_autocorrect_handle_audio'
-		), 1000 ); 
-		
+		), 1000 );
+
 		add_action( 'wp_head', array(
 			$this,
 			'cookiebot_addon_embed_autocorrect_javascript'
 		) );
 
 	}
-	
+
 	/**
 	 * Add javascript to handle videos as loaded
 	 *
@@ -132,12 +132,12 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 					jQuery('.wp-audio-shortcode__disabled').addClass('wp-audio-shortcode').removeClass('wp-audio-shortcode__disabled');
 					window.wp.mediaelement.initialize();
 				}
-			}, false ); 
+			}, false );
 			</script><?php
 		}
 	}
-	
-	
+
+
 	/**
 	 * Autocorrection of Vimeo and Youtube tags to make them GDPR compatible
 	 *
@@ -151,15 +151,15 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 			//Find src.
 			preg_match( '|<a href=\"([^\"]*)\">([^<]*)</a></p></blockquote>|', $match, $matchSrc );
 			$src = $matchSrc[1];
-			
+
 			//Replace - and add cookie consent notice.
 			$adjusted = str_replace( '<script>', '<script type="text/plain" data-cookieconsent="' . cookiebot_addons_output_cookie_types( $this->get_cookie_types() ) . '">', $match );
-			
+
 			/**
 			 * Generate placeholder
 			 */
 			$placeholder = $this->generate_placeholder_with_src( apply_filters( 'cookiebot_addons_embed_source', $src ) );
-			
+
 			/**
 			 * Modify placeholder by Filter
 			 *
@@ -168,27 +168,27 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 			 * @param   $this           array   Array of required cookie types
 			 */
 			$placeholder = apply_filters( 'cookiebot_addons_embed_placeholder', $placeholder, $src, $this->get_cookie_types() );
-			
+
 			$adjusted .= $placeholder;
 			$content  = str_replace( $match, $adjusted, $content );
-		
+
 		}
 		unset( $matches );
-		
+
 		preg_match_all( '|<blockquote[^>]*class=\"twitter-tweet\"[^>]*>.*?</script></p>|si', $content, $matches );
 		foreach ( $matches[0] as $match ) {
 			//Find src.
 			preg_match( '|<a href=\"([^\"]*)\">([^<]*)</a></p></blockquote>|', $match, $matchSrc );
 			$src = $matchSrc[1];
-			
+
 			//Replace - and add cookie consent notice.
 			$adjusted = str_replace( '<script ', '<script type="text/plain" data-cookieconsent="' . cookiebot_addons_output_cookie_types( $this->get_cookie_types() ) . '" ', $match );
-			
+
 			/**
 			 * Generate placeholder
 			 */
 			$placeholder = $this->generate_placeholder_with_src( apply_filters( 'cookiebot_addons_embed_source', $src ) );
-			
+
 			/**
 			 * Modify placeholder by Filter
 			 *
@@ -197,16 +197,16 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 			 * @param   $this           array   Array of required cookie types
 			 */
 			$placeholder = apply_filters( 'cookiebot_addons_embed_placeholder', $placeholder, $src, $this->get_cookie_types() );
-			
+
 			$adjusted .= $placeholder;
 			$content  = str_replace( $match, $adjusted, $content );
-		
+
 		}
 		unset( $matches );
-		
-		
+
+
 		//Match all youtube, vimeo and facebook iframes.
-		preg_match_all( '/<iframe[^>]*src=\"[^\"]*(facebook\.com|youtu\.be|youtube\.com|youtube-nocookie\.com|player\.vimeo\.com)\/[^>]*>.*?<\\/iframe>/mi', $content, $matches );
+		preg_match_all( '/<iframe[^>]* src=\"[^\"]*(facebook\.com|youtu\.be|youtube\.com|youtube-nocookie\.com|player\.vimeo\.com)\/[^>]*>.*?<\\/iframe>/mi', $content, $matches );
 		foreach ( $matches[0] as $match ) {
 			/**
 			 * Get the source attribute value
@@ -214,15 +214,15 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 			$start = strpos( $match, ' src="' ) + 6;
 			$end   = strpos( $match, '"', $start );
 			$src   = substr( $match, $start, $end - $start );
-			
+
 			//Replace - and add cookie consent notice.
 			$adjusted = str_replace( ' src=', ' data-cookieconsent="' . cookiebot_addons_output_cookie_types( $this->get_cookie_types() ) . '" data-src=', $match );
-			
+
 			/**
 			 * Generate placeholder
 			 */
 			$placeholder = $this->generate_placeholder_with_src( apply_filters( 'cookiebot_addons_embed_source', $src ) );
-			
+
 			/**
 			 * Modify placeholder by Filter
 			 *
@@ -231,18 +231,18 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 			 * @param   $this           array   Array of required cookie types
 			 */
 			$placeholder = apply_filters( 'cookiebot_addons_embed_placeholder', $placeholder, $src, $this->get_cookie_types() );
-			
+
 			$adjusted .= $placeholder;
 			$content  = str_replace( $match, $adjusted, $content );
 		}
-		
-		
-		
-	
-		
+
+
+
+
+
 		return $content;
 	}
-	
+
 	/**
 	 * Implementation of filter wp_video_shortcode - fixing code for cookiebot.
 	 */
@@ -252,14 +252,14 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 		 */
 		$placeholder = $this->generate_placeholder_with_src( apply_filters( 'cookiebot_addons_embed_source', $src ) );
 		$placeholder = apply_filters( 'cookiebot_addons_embed_placeholder', $placeholder, $src, $this->get_cookie_types() );
-			
-			
+
+
 		$output = str_replace( 'wp-video-shortcode','wp-video-shortcode__disabled', $output );
 		$output = str_replace( ' src=', ' data-cookieconsent="' . cookiebot_addons_output_cookie_types( $this->get_cookie_types() ) . '" data-src=', $output );
 		$output.= $placeholder;
 		return $output;
 	}
-	
+
 	/**
 	 * Implementation of filter wp_audio_shortcode - fixing code for cookiebot.
 	 */
@@ -269,13 +269,13 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 		 */
 		$placeholder = $this->generate_placeholder_with_src( apply_filters( 'cookiebot_addons_embed_source', $src ) );
 		$placeholder = apply_filters( 'cookiebot_addons_embed_placeholder', $placeholder, $src, $this->get_cookie_types() );
-			
+
 		$output = str_replace( 'wp-audio-shortcode','wp-audio-shortcode__disabled', $output );
 		$output = str_replace( ' src=', ' data-cookieconsent="' . cookiebot_addons_output_cookie_types( $this->get_cookie_types() ) . '" data-src=', $output );
 		$output.= $placeholder;
 		return $output;
 	}
-	
+
 	/**
 	 * Generates placeholder for given source
 	 *
@@ -287,10 +287,10 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 		$cookieContentNotice = '<div class="cookieconsent-optout-' . cookiebot_addons_get_one_cookie_type( $this->get_cookie_types() ) . '">';
 		$cookieContentNotice .= $this->get_placeholder( $src );
 		$cookieContentNotice .= '</div>';
-		
+
 		return $cookieContentNotice;
 	}
-	
+
 	/**
 	 * Return addon/plugin name
 	 *
@@ -301,7 +301,7 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 	public function get_addon_name() {
 		return 'Embed autocorrect';
 	}
-	
+
 	/**
 	 * Option name in the database
 	 *
@@ -312,7 +312,7 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 	public function get_option_name() {
 		return 'embed_autocorrect';
 	}
-	
+
 	/**
 	 * Plugin file path
 	 *
@@ -323,7 +323,7 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 	public function get_plugin_file() {
 		return false;
 	}
-	
+
 	/**
 	 * Returns checked cookie types
 	 * @return mixed
@@ -333,7 +333,7 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 	public function get_cookie_types() {
 		return $this->settings->get_cookie_types( $this->get_option_name(), $this->get_default_cookie_types() );
 	}
-	
+
 	/**
 	 * Returns default cookie types
 	 * @return array
@@ -343,7 +343,7 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 	public function get_default_cookie_types() {
 		return array( 'marketing', 'statistics' );
 	}
-	
+
 	/**
 	 * Check if plugin is activated and checked in the backend
 	 *
@@ -352,7 +352,7 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 	public function is_addon_enabled() {
 		return $this->settings->is_addon_enabled( $this->get_option_name() );
 	}
-	
+
 	/**
 	 * Checks if addon is installed
 	 *
@@ -361,7 +361,7 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 	public function is_addon_installed() {
 		return $this->settings->is_addon_installed( $this->get_plugin_file() );
 	}
-	
+
 	/**
 	 * Checks if addon is activated
 	 *
@@ -370,7 +370,7 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 	public function is_addon_activated() {
 		return $this->settings->is_addon_activated( $this->get_plugin_file() );
 	}
-	
+
 	/**
 	 * Default placeholder content
 	 *
@@ -381,7 +381,7 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 	public function get_default_placeholder() {
 		return 'Please accept [renew_consent]%cookie_types[/renew_consent] cookies to watch this video.';
 	}
-	
+
 	/**
 	 * Get placeholder content
 	 *
@@ -397,7 +397,7 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 	public function get_placeholder( $src = '' ) {
 		return $this->settings->get_placeholder( $this->get_option_name(), $this->get_default_placeholder(), cookiebot_addons_output_cookie_types( $this->get_cookie_types() ), $src );
 	}
-	
+
 	/**
 	 * Checks if it does have custom placeholder content
 	 *
@@ -408,7 +408,7 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 	public function has_placeholder() {
 		return $this->settings->has_placeholder( $this->get_option_name() );
 	}
-	
+
 	/**
 	 * returns all placeholder contents
 	 *
@@ -419,7 +419,7 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 	public function get_placeholders() {
 		return $this->settings->get_placeholders( $this->get_option_name() );
 	}
-	
+
 	/**
 	 * Return true if the placeholder is enabled
 	 *
@@ -430,7 +430,7 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 	public function is_placeholder_enabled() {
 		return $this->settings->is_placeholder_enabled( $this->get_option_name() );
 	}
-	
+
 	/**
 	 * Adds extra information under the label
 	 *
@@ -441,7 +441,7 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 	public function get_extra_information() {
 		return '<p>' . __( 'Blocks embedded videos from Youtube, Twitter, Vimeo and Facebook.', 'cookiebot-addons' ) . '</p>';
 	}
-	
+
 	/**
 	 * Returns the url of WordPress SVN repository or another link where we can verify the plugin file.
 	 *
@@ -452,7 +452,7 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 	public function get_svn_url() {
 		return false;
 	}
-	
+
 	/**
 	 * Placeholder helper overlay in the settings page.
 	 *

--- a/tests/integration/test-buffer-priorities.php
+++ b/tests/integration/test-buffer-priorities.php
@@ -3,40 +3,40 @@
 namespace cookiebot_addons\tests\integration;
 
 class Test_Buffer_Priorities extends \WP_UnitTestCase {
-	
+
 	public function setUp() {
-	
+
 	}
-	
+
 	/**
 	 * @covers \cookiebot_addons\controller\addons\custom_facebook_feed\Custom_Facebook_Feed
 	 */
 	public function test_custom_facebook_feed() {
 		$content = file_get_contents( 'http://plugins.svn.wordpress.org/custom-facebook-feed/trunk/custom-facebook-feed.php' );
-		
+
 		$this->assertNotFalse( strpos( $content, "add_action( 'wp_footer', 'cff_js' );" ) );
 	}
-	
+
 	/**
 	 * @covers \cookiebot_addons\controller\addons\caos_host_analyticsjs_local\CAOS_Host_Analyticsjs_Local
 	 */
 	public function test_host_analyticsjs_local() {
 		$content = file_get_contents( 'http://plugins.svn.wordpress.org/host-analyticsjs-local/trunk/save-ga-local.php' );
-		
-		$this->assertNotFalse( strpos( $content, 'add_action(\'wp_footer\', \'add_ga_header_script\', $sgal_enqueue_order);' ) );
-		$this->assertNotFalse( strpos( $content, 'add_action(\'wp_head\', \'add_ga_header_script\', $sgal_enqueue_order);' ) );
+
+		$this->assertNotFalse( strpos( $content, 'add_action(\'wp_footer\', \'caos_analytics_render_tracking_code\', $sgal_enqueue_order);' ) );
+		$this->assertNotFalse( strpos( $content, 'add_action(\'wp_head\', \'caos_analytics_render_tracking_code\', $sgal_enqueue_order);' ) );
 	}
-	
+
 	/**
 	 * @covers \cookiebot_addons\controller\addons\ga_google_analytics\Ga_Google_Analytics
 	 */
 	public function test_ga_google_analytics() {
 		$content = file_get_contents( 'http://plugins.svn.wordpress.org/ga-google-analytics/trunk/inc/plugin-core.php' );
-		
+
 		$this->assertNotFalse( strpos( $content, 'add_action(\'wp_head\', $function);' ) );
 		$this->assertNotFalse( strpos( $content, 'add_action(\'wp_footer\', $function);' ) );
 	}
-	
+
 	/**
 	 * @covers \cookiebot_addons|controller\addons\google_analyticator\Google_Analyticator
 	 */


### PR DESCRIPTION
CAOS changed function names in their latest release. It cause the Cookiebot plugin fails to ensure script is not loaded before consent is given.