### PR TITLE
Fix/googleplus badge

### DIFF
--- a/controller/addons/add-to-any/add-to-any.php
+++ b/controller/addons/add-to-any/add-to-any.php
@@ -236,6 +236,17 @@ class Add_To_Any implements Cookiebot_Addons_Interface {
 	public function is_addon_activated() {
 		return $this->settings->is_addon_activated( $this->get_plugin_file() );
 	}
+
+	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return $this->settings->get_addon_version( $this->get_plugin_file() );
+	}
 	
 	/**
 	 * Checks if it does have custom placeholder content

--- a/controller/addons/caos-host-analyticsjs-local/caos-host-analyticsjs-local.php
+++ b/controller/addons/caos-host-analyticsjs-local/caos-host-analyticsjs-local.php
@@ -207,6 +207,17 @@ class CAOS_Host_Analyticsjs_Local implements Cookiebot_Addons_Interface {
 	}
 
 	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return $this->settings->get_addon_version( $this->get_plugin_file() );
+	}
+
+	/**
 	 * Default placeholder content
 	 *
 	 * @return string

--- a/controller/addons/cookiebot-addons-interface.php
+++ b/controller/addons/cookiebot-addons-interface.php
@@ -123,6 +123,15 @@ Interface Cookiebot_Addons_Interface {
 	public function is_addon_activated();
 
 	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version();
+
+	/**
 	 * Checks if it does have custom placeholder content
 	 *
 	 * @return mixed

--- a/controller/addons/custom-facebook-feed-pro/custom-facebook-feed-pro.php
+++ b/controller/addons/custom-facebook-feed-pro/custom-facebook-feed-pro.php
@@ -186,6 +186,17 @@ class Custom_Facebook_Feed_Pro implements Cookiebot_Addons_Interface {
 	}
 
 	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return $this->settings->get_addon_version( $this->get_plugin_file() );
+	}
+
+	/**
 	 * Default placeholder content
 	 *
 	 * @return string

--- a/controller/addons/custom-facebook-feed/custom-facebook-feed.php
+++ b/controller/addons/custom-facebook-feed/custom-facebook-feed.php
@@ -186,6 +186,17 @@ class Custom_Facebook_Feed implements Cookiebot_Addons_Interface {
 	}
 
 	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return $this->settings->get_addon_version( $this->get_plugin_file() );
+	}
+
+	/**
 	 * Default placeholder content
 	 *
 	 * @return string

--- a/controller/addons/embed-autocorrect/embed-autocorrect.php
+++ b/controller/addons/embed-autocorrect/embed-autocorrect.php
@@ -374,6 +374,17 @@ class Embed_Autocorrect implements Cookiebot_Addons_Interface {
 	}
 
 	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return false;
+	}
+
+	/**
 	 * Default placeholder content
 	 *
 	 * @return string

--- a/controller/addons/facebook-for-woocommerce/facebook-for-woocommerce.php
+++ b/controller/addons/facebook-for-woocommerce/facebook-for-woocommerce.php
@@ -244,6 +244,17 @@ class Facebook_For_Woocommerce implements Cookiebot_Addons_Interface {
 	}
 
 	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return $this->settings->get_addon_version( $this->get_plugin_file() );
+	}
+
+	/**
 	 * Checks if it does have custom placeholder content
 	 *
 	 * @return mixed

--- a/controller/addons/ga-google-analytics/ga-google-analytics.php
+++ b/controller/addons/ga-google-analytics/ga-google-analytics.php
@@ -192,6 +192,17 @@ class Ga_Google_Analytics implements Cookiebot_Addons_Interface {
 	}
 
 	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return $this->settings->get_addon_version( $this->get_plugin_file() );
+	}
+
+	/**
 	 * Default placeholder content
 	 *
 	 * @return string

--- a/controller/addons/google-analyticator/google-analyticator.php
+++ b/controller/addons/google-analyticator/google-analyticator.php
@@ -204,6 +204,17 @@ class Google_Analyticator implements Cookiebot_Addons_Interface {
 	}
 
 	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return $this->settings->get_addon_version( $this->get_plugin_file() );
+	}
+
+	/**
 	 * Default placeholder content
 	 *
 	 * @return string

--- a/controller/addons/google-analytics-plus/google-analytics-plus.php
+++ b/controller/addons/google-analytics-plus/google-analytics-plus.php
@@ -178,6 +178,17 @@ class Google_Analytics_Plus implements Cookiebot_Addons_Interface {
 	}
 
 	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return $this->settings->get_addon_version( $this->get_plugin_file() );
+	}
+
+	/**
 	 * Default placeholder content
 	 *
 	 * @return string

--- a/controller/addons/google-analytics/google-analytics.php
+++ b/controller/addons/google-analytics/google-analytics.php
@@ -182,6 +182,17 @@ class Google_Analytics implements Cookiebot_Addons_Interface {
 	}
 
 	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return $this->settings->get_addon_version( $this->get_plugin_file() );
+	}
+
+	/**
 	 * Default placeholder content
 	 *
 	 * @return string

--- a/controller/addons/hubspot-leadin/hubspot-leadin.php
+++ b/controller/addons/hubspot-leadin/hubspot-leadin.php
@@ -174,6 +174,17 @@ class Hubspot_Leadin implements Cookiebot_Addons_Interface {
 	}
 
 	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return $this->settings->get_addon_version( $this->get_plugin_file() );
+	}
+
+	/**
 	 * Default placeholder content
 	 *
 	 * @return string

--- a/controller/addons/hubspot-tracking-code/hubspot-tracking-code.php
+++ b/controller/addons/hubspot-tracking-code/hubspot-tracking-code.php
@@ -187,6 +187,17 @@ class Hubspot_Tracking_Code implements Cookiebot_Addons_Interface {
 	}
 
 	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return $this->settings->get_addon_version( $this->get_plugin_file() );
+	}
+
+	/**
 	 * Default placeholder content
 	 *
 	 * @return string

--- a/controller/addons/instagram-feed/instagram-feed.php
+++ b/controller/addons/instagram-feed/instagram-feed.php
@@ -172,6 +172,17 @@ class Instagram_Feed implements Cookiebot_Addons_Interface {
 	}
 
 	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return $this->settings->get_addon_version( $this->get_plugin_file() );
+	}
+
+	/**
 	 * Default placeholder content
 	 *
 	 * @return string

--- a/controller/addons/jetpack/jetpack.php
+++ b/controller/addons/jetpack/jetpack.php
@@ -122,13 +122,6 @@ class Jetpack implements Cookiebot_Addons_Interface {
 		$this->widgets[] = new Visitor_Cookies( $this->settings, $this->script_loader_tag, $this->cookie_consent, $this->buffer_output, $this->get_widget_option() );
 
 		/**
-		 * Load configuration for googleplus badge widget
-		 *
-		 * @since 1.2.0
-		 */
-		$this->widgets[] = new Googleplus_Badge_Widget( $this->settings, $this->script_loader_tag, $this->cookie_consent, $this->buffer_output, $this->get_widget_option() );
-
-		/**
 		 * Load configuration for twitter timeline widget
 		 *
 		 * @since 1.2.0
@@ -148,6 +141,20 @@ class Jetpack implements Cookiebot_Addons_Interface {
 		 * @since 1.2.0
 		 */
 		$this->widgets[] = new Facebook_Widget( $this->settings, $this->script_loader_tag, $this->cookie_consent, $this->buffer_output, $this->get_widget_option() );
+
+		/**
+		 * If jetpack version is lower than 7 than add googleplus badge widget
+		 *
+		 * @since 2.2.1
+		 */
+		if( version_compare($this->get_addon_version(), '7', '<' ) ) {
+			/**
+			 * Load configuration for googleplus badge widget
+			 *
+			 * @since 1.2.0
+			 */
+			$this->widgets[] = new Googleplus_Badge_Widget( $this->settings, $this->script_loader_tag, $this->cookie_consent, $this->buffer_output, $this->get_widget_option() );
+		}
 	}
 
 	/**
@@ -250,6 +257,17 @@ class Jetpack implements Cookiebot_Addons_Interface {
 	 */
 	public function is_addon_activated() {
 		return $this->settings->is_addon_activated( $this->get_plugin_file() );
+	}
+
+	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return $this->settings->get_addon_version( $this->get_plugin_file() );
 	}
 
 	/**

--- a/controller/addons/ninja-forms/ninja-forms.php
+++ b/controller/addons/ninja-forms/ninja-forms.php
@@ -189,6 +189,17 @@ class Ninja_Forms implements Cookiebot_Addons_Interface {
 	}
 
 	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return $this->settings->get_addon_version( $this->get_plugin_file() );
+	}
+
+	/**
 	 * Default placeholder content
 	 *
 	 * @return string

--- a/controller/addons/optinmonster/optinmonster.php
+++ b/controller/addons/optinmonster/optinmonster.php
@@ -168,6 +168,17 @@ class Optinmonster implements Cookiebot_Addons_Interface {
 	}
 
 	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return $this->settings->get_addon_version( $this->get_plugin_file() );
+	}
+
+	/**
 	 * Default placeholder content
 	 *
 	 * @return string

--- a/controller/addons/pixel-caffeine/pixel-caffeine.php
+++ b/controller/addons/pixel-caffeine/pixel-caffeine.php
@@ -183,6 +183,17 @@ class Pixel_Caffeine implements Cookiebot_Addons_Interface {
 	}
 
 	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return $this->settings->get_addon_version( $this->get_plugin_file() );
+	}
+
+	/**
 	 * Default placeholder content
 	 *
 	 * @return string

--- a/controller/addons/wd-google-analytics/wd-google-analytics.php
+++ b/controller/addons/wd-google-analytics/wd-google-analytics.php
@@ -177,6 +177,17 @@ class Wd_Google_Analytics implements Cookiebot_Addons_Interface {
 	}
 
 	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return $this->settings->get_addon_version( $this->get_plugin_file() );
+	}
+
+	/**
 	 * Default placeholder content
 	 *
 	 * @return string

--- a/controller/addons/wp-analytify/wp-analytify.php
+++ b/controller/addons/wp-analytify/wp-analytify.php
@@ -170,6 +170,17 @@ class Wp_Analytify implements Cookiebot_Addons_Interface {
 	}
 
 	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return $this->settings->get_addon_version( $this->get_plugin_file() );
+	}
+
+	/**
 	 * Default placeholder content
 	 *
 	 * @return string

--- a/controller/addons/wp-piwik/wp-piwik.php
+++ b/controller/addons/wp-piwik/wp-piwik.php
@@ -172,6 +172,17 @@ class Wp_Piwik implements Cookiebot_Addons_Interface {
 	}
 
 	/**
+	 * Retrieves current installed version of the addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version() {
+		return $this->settings->get_addon_version( $this->get_plugin_file() );
+	}
+
+	/**
 	 * Default placeholder content
 	 *
 	 * @return string

--- a/lib/settings-service-interface.php
+++ b/lib/settings-service-interface.php
@@ -49,6 +49,17 @@ Interface Settings_Service_Interface {
 	public function is_addon_activated( $addon );
 
 	/**
+	 * Returns the addon version
+	 *
+	 * @param $addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version( $addon );
+
+	/**
 	 * Returns all cookie type for given addon
 	 *
 	 * @param $addon    string  option name

--- a/lib/settings-service.php
+++ b/lib/settings-service.php
@@ -64,7 +64,7 @@ class Settings_Service implements Settings_Service_Interface {
 	 * @since 2.2.1
 	 */
 	public function get_addon_version( $addon ) {
-		$plugin_data = get_plugin_data( $addon );
+		$plugin_data = get_file_data( WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . $addon, array( 'Version' => 'version' ), false );
 
 		return ( isset( $plugin_data['Version'] ) ) ? $plugin_data['Version'] : false;
 	}

--- a/lib/settings-service.php
+++ b/lib/settings-service.php
@@ -55,6 +55,21 @@ class Settings_Service implements Settings_Service_Interface {
 	}
 
 	/**
+	 * Returns the addon version
+	 *
+	 * @param $addon
+	 *
+	 * @return bool
+	 *
+	 * @since 2.2.1
+	 */
+	public function get_addon_version( $addon ) {
+		$plugin_data = get_plugin_data( $addon );
+
+		return ( isset( $plugin_data['Version'] ) ) ? $plugin_data['Version'] : false;
+	}
+
+	/**
 	 * Returns true if the addon plugin is activated
 	 *
 	 * @param $addon

--- a/tests/integration/addons/test-jetpack-googleplus-badge-widget.php
+++ b/tests/integration/addons/test-jetpack-googleplus-badge-widget.php
@@ -14,7 +14,7 @@ class Test_Jetpack_Googleplus_Badge_Widget extends \WP_UnitTestCase {
 	 * @since 2.1.0
 	 */
 	public function test_googleplus_badge_widget() {
-		$content = file_get_contents('http://plugins.svn.wordpress.org/jetpack/trunk/modules/widgets/googleplus-badge.php');
+		$content = file_get_contents('http://plugins.svn.wordpress.org/jetpack/tags/6.9/modules/widgets/googleplus-badge.php');
 		
 		$this->assertNotFalse( strpos( $content, 'wp_enqueue_script( \'googleplus-widget\',' ) );
 	}


### PR DESCRIPTION
The googleplus badge widget is removed from jetpack since the version 7.0.
Our current support will work for the versions before 7.0.